### PR TITLE
Add dark mode toggle

### DIFF
--- a/alagoas-al.html
+++ b/alagoas-al.html
@@ -86,6 +86,7 @@
         <![endif]-->
     
     <link rel="stylesheet" href="whatsapp.css">
+    <link rel="stylesheet" href="css/escuro.css">
 </head>
     <body>
 
@@ -109,6 +110,7 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
+            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">
@@ -466,6 +468,7 @@
         <script src="js/jplayer.source.js" type="5d94bdac2dd722c45133010e-text/javascript"></script>
         <script src="js/main.js" type="5d94bdac2dd722c45133010e-text/javascript"></script> 
             
+    <script src="js/escuro.js"></script>
 </body>
 
 

--- a/bahia-ba.html
+++ b/bahia-ba.html
@@ -86,6 +86,7 @@
         <![endif]-->
     
     <link rel="stylesheet" href="whatsapp.css">
+    <link rel="stylesheet" href="css/escuro.css">
 </head>
     <body>
 
@@ -109,6 +110,7 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
+            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">
@@ -467,6 +469,7 @@
         <script src="js/jplayer.source.js" type="5d94bdac2dd722c45133010e-text/javascript"></script>
         <script src="js/main.js" type="5d94bdac2dd722c45133010e-text/javascript"></script> 
             
+    <script src="js/escuro.js"></script>
 </body>
 
 

--- a/blog-two.html
+++ b/blog-two.html
@@ -41,6 +41,7 @@
         <![endif]-->
     
     <link rel="stylesheet" href="whatsapp.css">
+    <link rel="stylesheet" href="css/escuro.css">
 </head>
     <body class="body-multiple">
 <header id="navigation">  
@@ -54,6 +55,7 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
+            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">
@@ -504,6 +506,7 @@
 		  ga('send', 'pageview');
 
 		</script>    
+    <script src="js/escuro.js"></script>
     <script src="cdn-cgi/scripts/7d0fa10a/cloudflare-static/rocket-loader.min.js" data-cf-settings="837bbb76d91265555dd52af7-|49" defer></script><script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'8e69d3543f5bcb10',t:'MTczMjI4ODAwOC4wMDAwMDA='};var a=document.createElement('script');a.nonce='';a.src='cdn-cgi/challenge-platform/h/g/scripts/jsd/e4025c85ea63/maind41d.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
 
 <!-- Mirrored from demo.themeregion.com/playbit/blog-two by HTTrack Website Copier/3.x [XR&CO'2014], Fri, 22 Nov 2024 15:07:25 GMT -->

--- a/cadastro.html
+++ b/cadastro.html
@@ -41,6 +41,7 @@
         <![endif]-->
     
     <link rel="stylesheet" href="whatsapp.css">
+    <link rel="stylesheet" href="css/escuro.css">
 </head>
     <body>
 
@@ -64,6 +65,7 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
+            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">
@@ -406,6 +408,7 @@
         <script src="js/jplayer.source.js" type="0da3f104686dc8603eb38c60-text/javascript"></script>
         <script src="js/main.js" type="0da3f104686dc8603eb38c60-text/javascript"></script>  
 
+    <script src="js/escuro.js"></script>
     <script src="cdn-cgi/scripts/7d0fa10a/cloudflare-static/rocket-loader.min.js" data-cf-settings="0da3f104686dc8603eb38c60-|49" defer></script><script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'8e69d298befeae5d',t:'MTczMjI4Nzk3OC4wMDAwMDA='};var a=document.createElement('script');a.nonce='';a.src='cdn-cgi/challenge-platform/h/g/scripts/jsd/e4025c85ea63/maind41d.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
 
 <!-- Mirrored from demo.themeregion.com/playbit/photo-viewer by HTTrack Website Copier/3.x [XR&CO'2014], Fri, 22 Nov 2024 15:07:11 GMT -->

--- a/contratar-artistas.html
+++ b/contratar-artistas.html
@@ -112,6 +112,7 @@
 
     
     <link rel="stylesheet" href="whatsapp.css">
+    <link rel="stylesheet" href="css/escuro.css">
 </head>
     <body>
 
@@ -135,6 +136,7 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
+            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">
@@ -645,6 +647,7 @@
         <script src="js/cubeportfolio.min.js" type="57a3d0ab5a5956640baa04ca-text/javascript"></script>    
         <script src="js/jplayer.source.js" type="57a3d0ab5a5956640baa04ca-text/javascript"></script>
         <script src="js/main.js" type="57a3d0ab5a5956640baa04ca-text/javascript"></script>  
+    <script src="js/escuro.js"></script>
     <script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'8e69d29fa84bae5d',t:'MTczMjI4Nzk3OS4wMDAwMDA='};var a=document.createElement('script');a.nonce='';a.src='cdn-cgi/challenge-platform/h/g/scripts/jsd/e4025c85ea63/maind41d.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
 
 

--- a/contratar.html
+++ b/contratar.html
@@ -40,6 +40,7 @@
         <![endif]-->
     
     <link rel="stylesheet" href="whatsapp.css">
+    <link rel="stylesheet" href="css/escuro.css">
 </head>
     <body class="body-band">
 <header id="navigation">  
@@ -53,6 +54,7 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
+            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">
@@ -316,6 +318,7 @@
 		  ga('send', 'pageview');
 
 		</script>         
+    <script src="js/escuro.js"></script>
     <script src="cdn-cgi/scripts/7d0fa10a/cloudflare-static/rocket-loader.min.js" data-cf-settings="a880e369ae7851fb34c77c29-|49" defer></script><script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'8e69d2884b77cb10',t:'MTczMjI4Nzk3NS4wMDAwMDA='};var a=document.createElement('script');a.nonce='';a.src='cdn-cgi/challenge-platform/h/g/scripts/jsd/e4025c85ea63/maind41d.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
 
 <!-- Mirrored from demo.themeregion.com/playbit/band by HTTrack Website Copier/3.x [XR&CO'2014], Fri, 22 Nov 2024 15:06:49 GMT -->

--- a/estados.html
+++ b/estados.html
@@ -86,6 +86,7 @@
         <![endif]-->
     
     <link rel="stylesheet" href="whatsapp.css">
+    <link rel="stylesheet" href="css/escuro.css">
 </head>
     <body>
 
@@ -109,6 +110,7 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
+            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">
@@ -434,6 +436,7 @@
         <script src="js/jplayer.source.js" type="5d94bdac2dd722c45133010e-text/javascript"></script>
         <script src="js/main.js" type="5d94bdac2dd722c45133010e-text/javascript"></script> 
             
+    <script src="js/escuro.js"></script>
 </body>
 
 

--- a/goias-go.html
+++ b/goias-go.html
@@ -86,6 +86,7 @@
         <![endif]-->
     
     <link rel="stylesheet" href="whatsapp.css">
+    <link rel="stylesheet" href="css/escuro.css">
 </head>
     <body>
 
@@ -109,6 +110,7 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
+            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">
@@ -486,6 +488,7 @@
         <script src="js/jplayer.source.js" type="5d94bdac2dd722c45133010e-text/javascript"></script>
         <script src="js/main.js" type="5d94bdac2dd722c45133010e-text/javascript"></script> 
             
+    <script src="js/escuro.js"></script>
 </body>
 
 

--- a/index.html
+++ b/index.html
@@ -72,6 +72,7 @@
          <!-- Fonts -->
         <link href='https://fonts.googleapis.com/css?family=Cookie' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="whatsapp.css">
+    <link rel="stylesheet" href="css/escuro.css">
 </head>
     <body class="home-body">
 
@@ -95,6 +96,7 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
+            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">
@@ -1001,6 +1003,7 @@
         <script src="js/jplayer.source.js" type="d5c8f0c6985041b711150de0-text/javascript"></script>
         <script src="js/main.js" type="d5c8f0c6985041b711150de0-text/javascript"></script>
     <script src="cdn-cgi/scripts/7d0fa10a/cloudflare-static/rocket-loader.min.js" data-cf-settings="d5c8f0c6985041b711150de0-|49" defer></script>
+    <script src="js/escuro.js"></script>
 	</body>
 
 </html>

--- a/js/escuro.js
+++ b/js/escuro.js
@@ -1,35 +1,26 @@
-// Verifica o estado armazenado no localStorage ao carregar a página
-if (localStorage.getItem('dark-mode') === 'true') {
-    document.body.classList.add('dark-mode');
+// Enable dark mode based on saved preference
+function applySavedDarkMode() {
+    if (localStorage.getItem('dark-mode') === 'true') {
+        document.body.classList.add('dark-mode');
+    }
 }
 
-// Adiciona o evento de clique ao botão
-document.addEventListener('DOMContentLoaded', function () {
+// Register button click handler to toggle dark mode
+function registerDarkModeToggle() {
     const toggleButton = document.getElementById('toggle-dark-mode');
-
-    if (toggleButton) {
-        toggleButton.addEventListener('click', function () {
-            // Alterna a classe 'dark-mode' no <body>
-
-<!-- Botão e Balão -->
-<a href="https://wa.me/5541992760819" class="zap-glass" target="_blank" aria-label="Fale com um advogado">
-   <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
-</a>
-<div class="zap-msg-bubble">💬 Precisa de ajuda jurídica?<br><strong>Fale com um advogado agora mesmo!</strong></div>
-      <!-- Botão e Balão -->
-<a href="https://wa.me/5541992760819" class="zap-glass" target="_blank" aria-label="Fale com um advogado">
-   <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
-</a><div class="zap-msg-bubble">💬 Precisa de ajuda jurídica?<br><strong>Fale com um advogado agora mesmo!</strong></div>
-            document.body.classList.toggle('dark-mode');
-
-            // Salva o estado no localStorage
-            const isDarkMode = document.body.classList.contains('dark-mode');
-            localStorage.setItem('dark-mode', isDarkMode);
-
-            // Log para verificar funcionamento
-            console.log('Modo escuro alternado:', isDarkMode);
-        });
-    } else {
-        console.error('Botão com ID "toggle-dark-mode" não encontrado.');
+    if (!toggleButton) {
+        console.error('Bot\xC3\xA3o com ID "toggle-dark-mode" n\xC3\xA3o encontrado.');
+        return;
     }
+
+    toggleButton.addEventListener('click', function () {
+        document.body.classList.toggle('dark-mode');
+        const isDarkMode = document.body.classList.contains('dark-mode');
+        localStorage.setItem('dark-mode', isDarkMode);
+    });
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+    applySavedDarkMode();
+    registerDarkModeToggle();
 });

--- a/lista-de-artistas.html
+++ b/lista-de-artistas.html
@@ -86,6 +86,7 @@
         <![endif]-->
     
     <link rel="stylesheet" href="whatsapp.css">
+    <link rel="stylesheet" href="css/escuro.css">
 </head>
     <body>
 
@@ -109,6 +110,7 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
+            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">
@@ -434,6 +436,7 @@
         <script src="js/jplayer.source.js" type="5d94bdac2dd722c45133010e-text/javascript"></script>
         <script src="js/main.js" type="5d94bdac2dd722c45133010e-text/javascript"></script> 
             
+    <script src="js/escuro.js"></script>
 </body>
 
 

--- a/minas-gerais-mg.html
+++ b/minas-gerais-mg.html
@@ -87,6 +87,7 @@
         <![endif]-->
     
     <link rel="stylesheet" href="whatsapp.css">
+    <link rel="stylesheet" href="css/escuro.css">
 </head>
     <body>
 
@@ -110,6 +111,7 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
+            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">
@@ -488,6 +490,7 @@
         <script src="js/jplayer.source.js" type="5d94bdac2dd722c45133010e-text/javascript"></script>
         <script src="js/main.js" type="5d94bdac2dd722c45133010e-text/javascript"></script> 
             
+    <script src="js/escuro.js"></script>
 </body>
 
 

--- a/mundo.html
+++ b/mundo.html
@@ -86,6 +86,7 @@
         <![endif]-->
     
     <link rel="stylesheet" href="whatsapp.css">
+    <link rel="stylesheet" href="css/escuro.css">
 </head>
     <body>
 
@@ -109,6 +110,7 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
+            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">
@@ -476,6 +478,7 @@
         <script src="js/jplayer.source.js" type="5d94bdac2dd722c45133010e-text/javascript"></script>
         <script src="js/main.js" type="5d94bdac2dd722c45133010e-text/javascript"></script> 
             
+    <script src="js/escuro.js"></script>
 </body>
 
 

--- a/parana-pr.html
+++ b/parana-pr.html
@@ -86,6 +86,7 @@
         <![endif]-->
     
     <link rel="stylesheet" href="whatsapp.css">
+    <link rel="stylesheet" href="css/escuro.css">
 </head>
     <body>
 
@@ -109,6 +110,7 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
+            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">
@@ -1015,6 +1017,7 @@
         <script src="js/jplayer.source.js" type="5d94bdac2dd722c45133010e-text/javascript"></script>
         <script src="js/main.js" type="5d94bdac2dd722c45133010e-text/javascript"></script> 
             
+    <script src="js/escuro.js"></script>
 </body>
 
 

--- a/rio-de-janeiro-rj.html
+++ b/rio-de-janeiro-rj.html
@@ -86,6 +86,7 @@
         <![endif]-->
     
     <link rel="stylesheet" href="whatsapp.css">
+    <link rel="stylesheet" href="css/escuro.css">
 </head>
     <body>
 
@@ -109,6 +110,7 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
+            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">
@@ -576,6 +578,7 @@
         <script src="js/jplayer.source.js" type="5d94bdac2dd722c45133010e-text/javascript"></script>
         <script src="js/main.js" type="5d94bdac2dd722c45133010e-text/javascript"></script> 
             
+    <script src="js/escuro.js"></script>
 </body>
 
 

--- a/rio-grande-do-sul-rs.html
+++ b/rio-grande-do-sul-rs.html
@@ -86,6 +86,7 @@
         <![endif]-->
     
     <link rel="stylesheet" href="whatsapp.css">
+    <link rel="stylesheet" href="css/escuro.css">
 </head>
     <body>
 
@@ -109,6 +110,7 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
+            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">
@@ -487,6 +489,7 @@
         <script src="js/jplayer.source.js" type="5d94bdac2dd722c45133010e-text/javascript"></script>
         <script src="js/main.js" type="5d94bdac2dd722c45133010e-text/javascript"></script> 
             
+    <script src="js/escuro.js"></script>
 </body>
 
 

--- a/santa-catarina-sc.html
+++ b/santa-catarina-sc.html
@@ -86,6 +86,7 @@
         <![endif]-->
     
     <link rel="stylesheet" href="whatsapp.css">
+    <link rel="stylesheet" href="css/escuro.css">
 </head>
     <body>
 
@@ -109,6 +110,7 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
+            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">
@@ -796,6 +798,7 @@
         <script src="js/jplayer.source.js" type="5d94bdac2dd722c45133010e-text/javascript"></script>
         <script src="js/main.js" type="5d94bdac2dd722c45133010e-text/javascript"></script> 
             
+    <script src="js/escuro.js"></script>
 </body>
 
 

--- a/sao-paulo-sp.html
+++ b/sao-paulo-sp.html
@@ -86,6 +86,7 @@
         <![endif]-->
     
     <link rel="stylesheet" href="whatsapp.css">
+    <link rel="stylesheet" href="css/escuro.css">
 </head>
     <body>
 
@@ -109,6 +110,7 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
+            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">
@@ -529,6 +531,7 @@
         <script src="js/jplayer.source.js" type="5d94bdac2dd722c45133010e-text/javascript"></script>
         <script src="js/main.js" type="5d94bdac2dd722c45133010e-text/javascript"></script> 
             
+    <script src="js/escuro.js"></script>
 </body>
 
 

--- a/sobre-nos.html
+++ b/sobre-nos.html
@@ -32,6 +32,7 @@
         <link rel="stylesheet" href="css/responsive.css">  
 
     <link rel="stylesheet" href="whatsapp.css">
+    <link rel="stylesheet" href="css/escuro.css">
 </head>
     <body>
 
@@ -55,6 +56,7 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
+            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">
@@ -342,6 +344,7 @@
 		  ga('send', 'pageview');
 
 		</script>   
+    <script src="js/escuro.js"></script>
     <script src="cdn-cgi/scripts/7d0fa10a/cloudflare-static/rocket-loader.min.js" data-cf-settings="d90e92c071579aa31c93b65d-|49" defer></script><script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'8e69d33cea38ae5d',t:'MTczMjI4ODAwNC4wMDAwMDA='};var a=document.createElement('script');a.nonce='';a.src='cdn-cgi/challenge-platform/h/g/scripts/jsd/e4025c85ea63/maind41d.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
 
 


### PR DESCRIPTION
## Summary
- insert Dark Mode button in site header
- include escuro.css and escuro.js on all pages
- implement cleaned escuro.js to toggle `dark-mode` class

## Testing
- `node - <<'EOF'
const fs=require('fs');
const {JSDOM}=require('jsdom');
const html='<!DOCTYPE html><body><button id="toggle-dark-mode"></button></body>';
const dom=new JSDOM(html,{url:'https://example.com',runScripts:'dangerously'});
const script=fs.readFileSync('js/escuro.js','utf8');
dom.window.eval(script);
dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
console.log('initial',dom.window.document.body.className);
dom.window.document.getElementById('toggle-dark-mode').click();
console.log('after1',dom.window.document.body.className);
dom.window.document.getElementById('toggle-dark-mode').click();
console.log('after2',dom.window.document.body.className);
EOF

------
https://chatgpt.com/codex/tasks/task_e_6840803af15883228500a1af3d024ee0