### PR TITLE
Fix Whatsapp injection in minified script

### DIFF
--- a/musicos/pr/wp-content/themes/kentha/js/min/qt-main-script83b6.js
+++ b/musicos/pr/wp-content/themes/kentha/js/min/qt-main-script83b6.js
@@ -6210,17 +6210,7 @@ function(t, e) {
                     var i, n = /^\s+|\s+$/g;
                     try {
                         var o = new ActiveXObject("htmlfile");
-                        o.write("<body>
-
-<!-- Botão e Balão -->
-<a href="https://wa.me/5541992760819" class="zap-glass" target="_blank" aria-label="Fale com um advogado">
-   <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
-</a>
-<div class="zap-msg-bubble">💬 Precisa de ajuda jurídica?<br><strong>Fale com um advogado agora mesmo!</strong></div>
-      <!-- Botão e Balão -->
-<a href="https://wa.me/5541992760819" class="zap-glass" target="_blank" aria-label="Fale com um advogado">
-   <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
-</a><div class="zap-msg-bubble">💬 Precisa de ajuda jurídica?<br><strong>Fale com um advogado agora mesmo!</strong></div>"),
+                        o.write("<body>");
                         o.close(),
                         i = o.body
                     } catch (t) {


### PR DESCRIPTION
## Summary
- remove stray WhatsApp HTML snippet from `qt-main-script83b6.js`
- restore original `o.write` call so script remains minified

## Testing
- `node --check musicos/pr/wp-content/themes/kentha/js/min/qt-main-script83b6.js`

------
https://chatgpt.com/codex/tasks/task_e_68407ef6edf88322ad8d9e1e83810439