### PR TITLE
Deduplicate dark-mode toggles and WhatsApp widgets

### DIFF
--- a/alagoas-al.html
+++ b/alagoas-al.html
@@ -98,10 +98,6 @@
    <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
 </a>
 <div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
-      <!-- Botão e Balão -->
-<a href="https://bit.ly/musico-local" class="zap-glass" target="_blank" aria-label="Fale com um agente">
-   <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
-</a><div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
 <header id="navigation">  
     <div class="navbar fixed-top navbar-expand-lg">
         <div class="container">
@@ -113,7 +109,6 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
-            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">

--- a/bahia-ba.html
+++ b/bahia-ba.html
@@ -98,10 +98,6 @@
    <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
 </a>
 <div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
-      <!-- Botão e Balão -->
-<a href="https://bit.ly/musico-local" class="zap-glass" target="_blank" aria-label="Fale com um agente">
-   <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
-</a><div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
 <header id="navigation">  
     <div class="navbar fixed-top navbar-expand-lg">
         <div class="container">
@@ -113,7 +109,6 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
-            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">

--- a/blog-two.html
+++ b/blog-two.html
@@ -65,7 +65,6 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
-            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">

--- a/cadastro.html
+++ b/cadastro.html
@@ -51,10 +51,6 @@
    <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
 </a>
 <div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
-      <!-- Botão e Balão -->
-<a href="https://bit.ly/musico-local" class="zap-glass" target="_blank" aria-label="Fale com um agente">
-   <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
-</a><div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
 <header id="navigation">  
     <div class="navbar fixed-top navbar-expand-lg">
         <div class="container">
@@ -66,7 +62,6 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
-            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">

--- a/contratar-artistas.html
+++ b/contratar-artistas.html
@@ -122,10 +122,6 @@
    <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
 </a>
 <div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
-      <!-- Botão e Balão -->
-<a href="https://bit.ly/musico-local" class="zap-glass" target="_blank" aria-label="Fale com um agente">
-   <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
-</a><div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
 <header id="navigation">  
     <div class="navbar fixed-top navbar-expand-lg">
         <div class="container">
@@ -137,7 +133,6 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
-            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">

--- a/contratar.html
+++ b/contratar.html
@@ -63,7 +63,6 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
-            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">

--- a/css/owl.video.play.html
+++ b/css/owl.video.play.html
@@ -57,10 +57,6 @@
    <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
 </a>
 <div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
-      <!-- Botão e Balão -->
-<a href="https://bit.ly/musico-local" class="zap-glass" target="_blank" aria-label="Fale com um agente">
-   <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
-</a><div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
 
     <div class="error" id="error">
             <div class="container">

--- a/estados.html
+++ b/estados.html
@@ -96,10 +96,6 @@
    <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
 </a>
 <div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
-      <!-- Botão e Balão -->
-<a href="https://bit.ly/musico-local" class="zap-glass" target="_blank" aria-label="Fale com um agente">
-   <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
-</a><div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
 <header id="navigation">  
     <div class="navbar fixed-top navbar-expand-lg">
         <div class="container">
@@ -111,7 +107,6 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
-            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">

--- a/goias-go.html
+++ b/goias-go.html
@@ -98,10 +98,6 @@
    <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
 </a>
 <div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
-      <!-- Botão e Balão -->
-<a href="https://bit.ly/musico-local" class="zap-glass" target="_blank" aria-label="Fale com um agente">
-   <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
-</a><div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
 <header id="navigation">  
     <div class="navbar fixed-top navbar-expand-lg">
         <div class="container">
@@ -113,7 +109,6 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
-            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">

--- a/image/jplayer.blue.monday.html
+++ b/image/jplayer.blue.monday.html
@@ -57,10 +57,6 @@
    <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
 </a>
 <div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
-      <!-- Botão e Balão -->
-<a href="https://bit.ly/musico-local" class="zap-glass" target="_blank" aria-label="Fale com um agente">
-   <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
-</a><div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
 
     <div class="error" id="error">
             <div class="container">

--- a/img/cbp-sprite.html
+++ b/img/cbp-sprite.html
@@ -57,10 +57,6 @@
    <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
 </a>
 <div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
-      <!-- Botão e Balão -->
-<a href="https://bit.ly/musico-local" class="zap-glass" target="_blank" aria-label="Fale com um agente">
-   <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
-</a><div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
 
     <div class="error" id="error">
             <div class="container">

--- a/index.html
+++ b/index.html
@@ -82,10 +82,6 @@
    <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
 </a>
 <div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
-      <!-- Botão e Balão -->
-<a href="https://bit.ly/musico-local" class="zap-glass" target="_blank" aria-label="Fale com um agente">
-   <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
-</a><div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
 <header id="navigation">  
     <div class="navbar fixed-top navbar-expand-lg">
         <div class="container">
@@ -97,7 +93,6 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
-            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">

--- a/lista-de-artistas.html
+++ b/lista-de-artistas.html
@@ -96,10 +96,6 @@
    <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
 </a>
 <div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
-      <!-- Botão e Balão -->
-<a href="https://bit.ly/musico-local" class="zap-glass" target="_blank" aria-label="Fale com um agente">
-   <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
-</a><div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
 <header id="navigation">  
     <div class="navbar fixed-top navbar-expand-lg">
         <div class="container">
@@ -111,7 +107,6 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
-            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">

--- a/minas-gerais-mg.html
+++ b/minas-gerais-mg.html
@@ -98,10 +98,6 @@
    <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
 </a>
 <div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
-      <!-- Botão e Balão -->
-<a href="https://bit.ly/musico-local" class="zap-glass" target="_blank" aria-label="Fale com um agente">
-   <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
-</a><div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
 <header id="navigation">  
     <div class="navbar fixed-top navbar-expand-lg">
         <div class="container">
@@ -113,7 +109,6 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
-            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">

--- a/mundo.html
+++ b/mundo.html
@@ -96,10 +96,6 @@
    <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
 </a>
 <div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
-      <!-- Botão e Balão -->
-<a href="https://bit.ly/musico-local" class="zap-glass" target="_blank" aria-label="Fale com um agente">
-   <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
-</a><div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
 <header id="navigation">  
     <div class="navbar fixed-top navbar-expand-lg">
         <div class="container">
@@ -111,7 +107,6 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
-            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">

--- a/parana-pr.html
+++ b/parana-pr.html
@@ -96,10 +96,6 @@
    <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
 </a>
 <div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
-      <!-- Botão e Balão -->
-<a href="https://bit.ly/musico-local" class="zap-glass" target="_blank" aria-label="Fale com um agente">
-   <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
-</a><div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
 <header id="navigation">  
     <div class="navbar fixed-top navbar-expand-lg">
         <div class="container">
@@ -111,7 +107,6 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
-            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">

--- a/pr/about - Copia.html
+++ b/pr/about - Copia.html
@@ -51,10 +51,6 @@
    <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
 </a>
 <div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
-      <!-- Botão e Balão -->
-<a href="https://bit.ly/musico-local" class="zap-glass" target="_blank" aria-label="Fale com um agente">
-   <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
-</a><div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
         <header id="navigation">  
             <div class="navbar fixed-top navbar-expand-lg">
                 <div class="container">

--- a/rio-de-janeiro-rj.html
+++ b/rio-de-janeiro-rj.html
@@ -97,10 +97,6 @@
    <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
 </a>
 <div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
-      <!-- Botão e Balão -->
-<a href="https://bit.ly/musico-local" class="zap-glass" target="_blank" aria-label="Fale com um agente">
-   <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
-</a><div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
 <header id="navigation">  
     <div class="navbar fixed-top navbar-expand-lg">
         <div class="container">
@@ -112,7 +108,6 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
-            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">

--- a/rio-grande-do-sul-rs.html
+++ b/rio-grande-do-sul-rs.html
@@ -97,10 +97,6 @@
    <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
 </a>
 <div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
-      <!-- Botão e Balão -->
-<a href="https://bit.ly/musico-local" class="zap-glass" target="_blank" aria-label="Fale com um agente">
-   <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
-</a><div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
 <header id="navigation">  
     <div class="navbar fixed-top navbar-expand-lg">
         <div class="container">
@@ -112,7 +108,6 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
-            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">

--- a/santa-catarina-sc.html
+++ b/santa-catarina-sc.html
@@ -98,10 +98,6 @@
    <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
 </a>
 <div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
-      <!-- Botão e Balão -->
-<a href="https://bit.ly/musico-local" class="zap-glass" target="_blank" aria-label="Fale com um agente">
-   <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
-</a><div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
 <header id="navigation">  
     <div class="navbar fixed-top navbar-expand-lg">
         <div class="container">
@@ -113,7 +109,6 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
-            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">

--- a/sao-paulo-sp.html
+++ b/sao-paulo-sp.html
@@ -98,10 +98,6 @@
    <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
 </a>
 <div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
-      <!-- Botão e Balão -->
-<a href="https://bit.ly/musico-local" class="zap-glass" target="_blank" aria-label="Fale com um agente">
-   <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
-</a><div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
 <header id="navigation">  
     <div class="navbar fixed-top navbar-expand-lg">
         <div class="container">
@@ -113,7 +109,6 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
-            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">

--- a/sobre-nos.html
+++ b/sobre-nos.html
@@ -42,10 +42,6 @@
    <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
 </a>
 <div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
-      <!-- Botão e Balão -->
-<a href="https://bit.ly/musico-local" class="zap-glass" target="_blank" aria-label="Fale com um agente">
-   <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/whatsapp.svg" alt="WhatsApp">
-</a><div class="zap-msg-bubble">💬 Quer contratar um artista?<br><strong>Fale com um agente agora mesmo!</strong></div>
 <header id="navigation">  
     <div class="navbar fixed-top navbar-expand-lg">
         <div class="container">
@@ -57,7 +53,6 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainmenu" aria-controls="mainmenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"><i class="fa fa-align-justify"></i></span>
             </button>
-            <button id="toggle-dark-mode">Modo Escuro</button>
             <!-- Menu de Navegação -->
             <nav id="mainmenu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">


### PR DESCRIPTION
## Summary
- cleaned up duplicated markup on HTML pages
- ensure each page has only one `toggle-dark-mode` element
- keep only a single pair of WhatsApp button and bubble

## Testing
- `grep -c "toggle-dark-mode" *.html`


------
https://chatgpt.com/codex/tasks/task_e_6840bfe9d8b083228e415ba85842ed80